### PR TITLE
Fix build against XP 8 Java APIs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,14 @@ dependencies {
     include libs.lib.mustache
     include libs.lib.text.encoding
 
-    testImplementation 'junit:junit:4.13.2'
     testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:6.0.3'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.0.3'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.0.3'
+}
+
+test {
+    useJUnitPlatform()
 }
 
 repositories {

--- a/src/main/java/com/enonic/app/simpleidprovider/AuthenticateHandler.java
+++ b/src/main/java/com/enonic/app/simpleidprovider/AuthenticateHandler.java
@@ -1,20 +1,15 @@
 package com.enonic.app.simpleidprovider;
 
-import java.util.Comparator;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
-import javax.servlet.http.HttpSession;
+import org.osgi.service.component.annotations.Component;
 
 import com.enonic.xp.context.Context;
 import com.enonic.xp.context.ContextBuilder;
-import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.script.bean.ScriptBean;
-import com.enonic.xp.security.IdProvider;
 import com.enonic.xp.security.IdProviderKey;
-import com.enonic.xp.security.IdProviders;
 import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.SecurityConstants;
 import com.enonic.xp.security.SecurityService;
@@ -25,19 +20,11 @@ import com.enonic.xp.security.auth.EmailPasswordAuthToken;
 import com.enonic.xp.security.auth.UsernamePasswordAuthToken;
 import com.enonic.xp.security.auth.VerifiedEmailAuthToken;
 import com.enonic.xp.security.auth.VerifiedUsernameAuthToken;
-import com.enonic.xp.session.Session;
-
-// import org.slf4j.Logger;
-// import org.slf4j.LoggerFactory;
-
-import org.osgi.service.component.annotations.Component;
 
 @Component(immediate = true)
 public final class AuthenticateHandler
     implements ScriptBean
 {
-    // private static final Logger LOG = LoggerFactory.getLogger( AuthenticationInfo.class );
-
     private String user;
 
     private String password;
@@ -49,8 +36,6 @@ public final class AuthenticateHandler
     private Supplier<SecurityService> securityService;
 
     private Supplier<Context> context;
-
-    private Supplier<PortalRequest> portalRequestSupplier;
 
     public void setUser( final String user )
     {
@@ -94,18 +79,13 @@ public final class AuthenticateHandler
         {
             if ( this.skipAuth )
             {
-                final VerifiedEmailAuthToken verifiedEmailAuthToken = new VerifiedEmailAuthToken();
-                verifiedEmailAuthToken.setEmail( this.user );
-                verifiedEmailAuthToken.setIdProvider( idProvider );
+                final VerifiedEmailAuthToken verifiedEmailAuthToken = new VerifiedEmailAuthToken( idProvider, this.user );
 
                 authInfo = runAsAuthenticated( () -> this.securityService.get().authenticate( verifiedEmailAuthToken ) );
             }
             else
             {
-                final EmailPasswordAuthToken emailAuthToken = new EmailPasswordAuthToken();
-                emailAuthToken.setEmail( this.user );
-                emailAuthToken.setPassword( this.password );
-                emailAuthToken.setIdProvider( idProvider );
+                final EmailPasswordAuthToken emailAuthToken = new EmailPasswordAuthToken( idProvider, this.user, this.password );
 
                 authInfo = runAsAuthenticated( () -> this.securityService.get().authenticate( emailAuthToken ) );
             }
@@ -115,18 +95,13 @@ public final class AuthenticateHandler
         {
             if ( this.skipAuth )
             {
-                final VerifiedUsernameAuthToken usernameAuthToken = new VerifiedUsernameAuthToken();
-                usernameAuthToken.setUsername( this.user );
-                usernameAuthToken.setIdProvider( idProvider );
+                final VerifiedUsernameAuthToken usernameAuthToken = new VerifiedUsernameAuthToken( idProvider, this.user );
 
                 authInfo = runAsAuthenticated( () -> this.securityService.get().authenticate( usernameAuthToken ) );
             }
             else
             {
-                final UsernamePasswordAuthToken usernameAuthToken = new UsernamePasswordAuthToken();
-                usernameAuthToken.setUsername( this.user );
-                usernameAuthToken.setPassword( this.password );
-                usernameAuthToken.setIdProvider( idProvider );
+                final UsernamePasswordAuthToken usernameAuthToken = new UsernamePasswordAuthToken( idProvider, this.user, this.password );
 
                 authInfo = runAsAuthenticated( () -> this.securityService.get().authenticate( usernameAuthToken ) );
             }
@@ -137,7 +112,7 @@ public final class AuthenticateHandler
 
     private <T> T runAsAuthenticated( Callable<T> runnable )
     {
-        final AuthenticationInfo authInfo = AuthenticationInfo.create().principals( RoleKeys.AUTHENTICATED ).user( User.ANONYMOUS ).build();
+        final AuthenticationInfo authInfo = AuthenticationInfo.create().principals( RoleKeys.AUTHENTICATED ).user( User.anonymous() ).build();
         return ContextBuilder.from( this.context.get() ).
             authInfo( authInfo ).
             repositoryId( SystemConstants.SYSTEM_REPO_ID ).
@@ -155,6 +130,5 @@ public final class AuthenticateHandler
     {
         this.securityService = context.getService( SecurityService.class );
         this.context = context.getBinding( Context.class );
-        this.portalRequestSupplier = context.getBinding( PortalRequest.class );
     }
 }

--- a/src/main/java/com/enonic/xp/app/users/lib/auth/DefaultPermissionsHandler.java
+++ b/src/main/java/com/enonic/xp/app/users/lib/auth/DefaultPermissionsHandler.java
@@ -3,16 +3,23 @@ package com.enonic.xp.app.users.lib.auth;
 import java.util.List;
 
 import com.enonic.xp.script.bean.BeanContext;
+import com.enonic.xp.security.RoleKeys;
 import com.enonic.xp.security.SecurityService;
+import com.enonic.xp.security.acl.IdProviderAccess;
+import com.enonic.xp.security.acl.IdProviderAccessControlEntry;
 import com.enonic.xp.security.acl.IdProviderAccessControlList;
 
 public final class DefaultPermissionsHandler
     extends AbstractPermissionsHandler
 {
+    private static final IdProviderAccessControlList DEFAULT_ID_PROVIDER_ACL = IdProviderAccessControlList.of(
+        IdProviderAccessControlEntry.create().principal( RoleKeys.ADMIN ).access( IdProviderAccess.ADMINISTRATOR ).build(),
+        IdProviderAccessControlEntry.create().principal( RoleKeys.USER_MANAGER_ADMIN ).access( IdProviderAccess.ADMINISTRATOR ).build(),
+        IdProviderAccessControlEntry.create().principal( RoleKeys.AUTHENTICATED ).access( IdProviderAccess.READ ).build() );
+
     public List<IdProviderAccessControlEntryMapper> defaultPermissions()
     {
-        final IdProviderAccessControlList idProviderPermissions = securityService.get().getDefaultIdProviderPermissions();
-        return mapIdProviderPermissions( idProviderPermissions );
+        return mapIdProviderPermissions( DEFAULT_ID_PROVIDER_ACL );
     }
 
     @Override

--- a/src/main/java/com/enonic/xp/app/users/lib/auth/IdProviderAccessControlEntryMapper.java
+++ b/src/main/java/com/enonic/xp/app/users/lib/auth/IdProviderAccessControlEntryMapper.java
@@ -1,9 +1,9 @@
 package com.enonic.xp.app.users.lib.auth;
 
-import com.enonic.xp.lib.common.PrincipalMapper;
 import com.enonic.xp.script.serializer.MapGenerator;
 import com.enonic.xp.script.serializer.MapSerializable;
 import com.enonic.xp.security.Principal;
+import com.enonic.xp.security.User;
 import com.enonic.xp.security.acl.IdProviderAccess;
 
 public class IdProviderAccessControlEntryMapper
@@ -29,7 +29,23 @@ public class IdProviderAccessControlEntryMapper
     private void serializePrincipal( final MapGenerator gen, final Principal principal )
     {
         gen.map( "principal" );
-        new PrincipalMapper( principal ).serialize( gen );
+        gen.value( "type", principal.getClass().getSimpleName().toLowerCase() );
+        gen.value( "key", principal.getKey() );
+        gen.value( "displayName", principal.getDisplayName() );
+        gen.value( "modifiedTime", principal.getModifiedTime() );
+        if ( principal instanceof User )
+        {
+            final User user = (User) principal;
+            gen.value( "disabled", user.isDisabled() );
+            gen.value( "email", user.getEmail() );
+            gen.value( "login", user.getLogin() );
+            gen.value( "idProvider", user.getKey() != null ? user.getKey().getIdProviderKey() : null );
+            gen.value( "hasPassword", user.getAuthenticationHash() != null );
+        }
+        else
+        {
+            gen.value( "description", principal.getDescription() );
+        }
         gen.end();
     }
 

--- a/src/main/java/com/enonic/xp/app/users/lib/auth/ScriptValueToIdProviderConfigTranslator.java
+++ b/src/main/java/com/enonic/xp/app/users/lib/auth/ScriptValueToIdProviderConfigTranslator.java
@@ -62,7 +62,7 @@ public final class ScriptValueToIdProviderConfigTranslator
         {
             if ( propertyValue != null && propertyValue.hasMember( "set" ) )
             {
-                final PropertySet newSet = parent.newSet();
+                final PropertySet newSet = parent.getTree().newSet();
                 for ( ScriptValue propertyArray : propertyValue.getMember( "set" ).getArray() )
                 {
                     addPropertyArray( propertyArray, newSet );

--- a/src/test/java/com/enonic/app/simpleidprovider/GravatarHashHandlerTest.java
+++ b/src/test/java/com/enonic/app/simpleidprovider/GravatarHashHandlerTest.java
@@ -3,15 +3,16 @@ package com.enonic.app.simpleidprovider;
 import java.io.UnsupportedEncodingException;
 import java.security.NoSuchAlgorithmException;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GravatarHashHandlerTest
 {
     private GravatarHashHandler gravatarHashHandler;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         gravatarHashHandler = new GravatarHashHandler();
@@ -23,7 +24,7 @@ public class GravatarHashHandlerTest
     {
         gravatarHashHandler.setEmail( "noreply@enonic.com" );
         final String hash = gravatarHashHandler.execute();
-        Assert.assertEquals( "0f7675b377ff59e85e37ed6ab24969d9", hash );
+        assertEquals( "0f7675b377ff59e85e37ed6ab24969d9", hash );
     }
 
 }

--- a/src/test/java/com/enonic/app/simpleidprovider/TokenGeneratorServiceTest.java
+++ b/src/test/java/com/enonic/app/simpleidprovider/TokenGeneratorServiceTest.java
@@ -1,14 +1,17 @@
 package com.enonic.app.simpleidprovider;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class TokenGeneratorServiceTest
 {
     private TokenGeneratorService tokenGeneratorService;
 
-    @Before
+    @BeforeEach
     public void setUp()
     {
         tokenGeneratorService = new TokenGeneratorService();
@@ -19,11 +22,11 @@ public class TokenGeneratorServiceTest
     {
         final String token = tokenGeneratorService.generateToken();
         final String token2 = tokenGeneratorService.generateToken();
-        Assert.assertNotNull( token );
-        Assert.assertNotNull( token2 );
-        Assert.assertEquals( 32, token.length() );
-        Assert.assertEquals( 32, token2.length() );
-        Assert.assertNotEquals( token, token2 );
+        assertNotNull( token );
+        assertNotNull( token2 );
+        assertEquals( 32, token.length() );
+        assertEquals( 32, token2.length() );
+        assertNotEquals( token, token2 );
     }
 
 }


### PR DESCRIPTION
## Root cause

`./gradlew clean build` on master fails with 20 Java compile errors caused by XP 8 platform changes that the app was never adapted to. Specifically: the auth tokens (`VerifiedEmailAuthToken`, `EmailPasswordAuthToken`, `VerifiedUsernameAuthToken`, `UsernamePasswordAuthToken`) are now immutable constructor-based, `User.ANONYMOUS` was replaced with `User.anonymous()`, `javax.servlet.*` is now `jakarta.servlet.*` (the offending import was unused), `com.enonic.xp.lib.common.PrincipalMapper` is no longer on the public surface, `PropertySet.newSet()` was moved to `PropertyTree.newSet()`, and `SecurityService.getDefaultIdProviderPermissions()` was deleted in `xp8 remove deprecated methods #11068`. As a smaller knock-on, the only unit tests that were running were the two JUnit 4 ones — the Jupiter-based `SimpleIdProviderTest` (`@TestFactory` via `ScriptRunnerSupport`) was silently skipped because the project lacked `useJUnitPlatform()` and the Jupiter engine/launcher on the test classpath.

## Changes

- `AuthenticateHandler`: drop unused `javax.servlet.http.HttpSession` import; use immutable AuthToken constructors; `User.ANONYMOUS` → `User.anonymous()`; drop the unused `PortalRequest` binding while we're here.
- `IdProviderAccessControlEntryMapper`: inline principal serialization (replaces the import of the now-internal `PrincipalMapper`).
- `ScriptValueToIdProviderConfigTranslator`: `parent.newSet()` → `parent.getTree().newSet()`.
- `DefaultPermissionsHandler`: inline the default ACL (admin + user-manager-admin = administrator, authenticated = read).
- Tests: migrate the two JUnit 4 tests to JUnit Jupiter, drop `junit:junit:4.13.2`, add `org.junit.jupiter:junit-jupiter-api`, `junit-jupiter-engine` (runtime), `junit-platform-launcher` (runtime), and enable `useJUnitPlatform()`. With this, all three test classes execute: `GravatarHashHandlerTest` (1), `TokenGeneratorServiceTest` (1), and `SimpleIdProviderTest` (7 dynamic JS tests) — 9 tests total, all passing.

## E2E verification

Built `simpleidprovider.jar`, deployed into a local XP 8 runtime (`xp/modules/runtime/build/install`, version `8.0.0-SNAPSHOT` — same API surface as B4 for the changes above; B4 was already verified to break in the same way by the build failures), started the server, deployed the jar, observed:

- Bundle 113 `com.enonic.app.simpleidprovider` installed and started cleanly.
- Application registered and configured by the OSGi runtime.
- Static asset endpoint `/.../asset/com.enonic.app.simpleidprovider:.../css/style.css` responds 200.
- One **harmless** WARN on startup: `Failed to provision simple id provider: authLib.getIdProviders is not a function`. This is from the `main.js` self-provisioning added in #72 and is **caught** in a try/catch — the app continues to function. The `getIdProviders`/`createIdProvider` JS exports were added to `lib-auth` *after* 8.0.0-B4 (commit `5eb82cab93`, 2026-05-05), so on B4 the auto-provisioning silently skips and the operator must create the id provider manually (as has always been the case). This is independent of the build fix and worth a separate look once a post-B4 XP release ships the JS API.

Full browser-based login/register/reset/logout flows were **not** exercised because this environment is headless (no browser, no display) and creating an id provider end-to-end requires either the admin UI or a configured idprovider in the security repo. The build, deploy, OSGi lifecycle, and asset paths are all green; the runtime behavior is the same as on master prior to the XP 8 platform changes, modulo the harmless WARN above.

## Distro used

Local build of `xp` (`/home/agent/workspace/xp/modules/runtime/build/install`, `8.0.0-SNAPSHOT`, master), since no published `enonic-xp-8.0.0-B4` distro tarball was available on the runner and `enonic CLI` requires Docker which isn't installed here. The relevant API surface (immutable AuthTokens, `User.anonymous()`, dropped `SecurityService.getDefaultIdProviderPermissions`, removed `PrincipalMapper`, `PropertySet.newSet()` → `PropertyTree.newSet()`) is identical between the snapshot and 8.0.0-B4 — these were merged into XP master before the B4 release.