### PR TITLE
Prepare 3.0.0 release #76

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = simpleidprovider
 appName = com.enonic.app.simpleidprovider
 xpVersion = 8.1.0-SNAPSHOT
-version = 2.2.1-SNAPSHOT
+version = 3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

Bump version to `3.0.0-SNAPSHOT` for the 3.0.0 release.

The original version of this PR carried a workaround that switched `main.js` to app-internal `CreateIdProviderHandler` / `GetIdProvidersHandler` script beans, because lib-auth at the time did not expose `idProviderConfig` and an id provider created via lib-auth would not be linked to this app. That workaround is no longer needed:

- The lib-auth fix landed on `enonic/xp` master in `fa26528a73 lib-auth: restore idProviderConfig #12041 (#12042)`.
- The proper cleanup landed on this app's master in #79: `main.js` stays on lib-auth, the dead `lib/auth` Java directory is gone, `xpVersion` is on `8.1.0-SNAPSHOT`, repo is `xp.enonicRepo('dev')`.

With master now correct, this branch reduces to a one-line version bump.

## Test plan

- [x] `./gradlew build` clean (E2E for the lib-auth path was verified on #79: cold-boot creates `simpleid` with `idProviderConfig.applicationKey = com.enonic.app.simpleidprovider`, restart hits the "already exists" branch, login routing through `/_/idprovider/simpleid` returns the app's login page).

Closes #76