### PR TITLE
Fix undefined site name in 2FA emails #63

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This ID Provider contains a simple login/logout page to authenticate your local 
 ### Step 2: Configure the ID provider and email authentication
 Configure the ID Provider:
 * Title: Title used by the login/logout page
+* Site name: Name of the site used in the subject and body of emails sent to users (password reset, two-factor authentication code)
 * Theme: Display theme of the login/logout page
 * Gravatar picture: If enabled, the Gravatar picture of the logged in user will be displayed on the logout page
 * (Optional) Session timeout: Session timeout (in seconds). By default, the value of session.timeout from com.enonic.xp.web.jetty.cfg
@@ -29,7 +30,6 @@ You need to have set up the mail configuration for "Forgot password" and Two-ste
 (See [Mail Configuration](https://developer.enonic.com/docs/xp/stable/deployment/config#mail) for more information).
 
 * Email author: The author of the password reset mail
-* Site name: Name used in the password reset mail body
 * (Optional) ReCaptcha: Add a reCaptcha field to the forgot password form.
 
 You need to have registered your website on reCaptcha (See [reCaptcha](https://www.google.com/recaptcha/admin) for more information).

--- a/src/main/resources/idprovider/idprovider.yaml
+++ b/src/main/resources/idprovider/idprovider.yaml
@@ -8,6 +8,15 @@ form:
       min: 0
       max: 1
     default: "User Login"
+  - type: "TextLine"
+    name: "siteName"
+    label: "Site name"
+    helpText: "Name of the site, used in the subject and body of emails sent to users\
+      \ (e.g. two-factor authentication codes, password reset)."
+    occurrences:
+      min: 0
+      max: 1
+    default: "MyWebsite"
   - type: "ComboBox"
     name: "theme"
     label: "Theme"
@@ -73,13 +82,6 @@ form:
           min: 0
           max: 1
         default: "noreply@example.com"
-      - type: "TextLine"
-        name: "site"
-        label: "Site name"
-        occurrences:
-          min: 1
-          max: 1
-        default: "MyWebsite"
       - type: "ItemSet"
         name: "reCaptcha"
         label: "ReCaptcha"

--- a/src/main/resources/lib/config.js
+++ b/src/main/resources/lib/config.js
@@ -41,8 +41,14 @@ function getEmail() {
 exports.getEmail = getEmail;
 
 function getSite() {
-    const forgotPassword = authLib.getIdProviderConfig().forgotPassword;
-    return forgotPassword && forgotPassword.site;
+    const config = authLib.getIdProviderConfig();
+    if (config.siteName) {
+        return config.siteName;
+    }
+    if (config.forgotPassword && config.forgotPassword.site) {
+        return config.forgotPassword.site;
+    }
+    return config.title;
 };
 exports.getSite = getSite;
 

--- a/src/main/resources/lib/config.js
+++ b/src/main/resources/lib/config.js
@@ -27,7 +27,7 @@ exports.getSessionTimeout = getSessionTimeout;
 
 function getForgotPassword() {
     const forgotPassword = authLib.getIdProviderConfig().forgotPassword;
-    if (forgotPassword && forgotPassword.site) {
+    if (forgotPassword) {
         return forgotPassword;
     }
     return null;

--- a/src/test/java/com/enonic/app/simpleidprovider/ConfigTest.java
+++ b/src/test/java/com/enonic/app/simpleidprovider/ConfigTest.java
@@ -1,0 +1,13 @@
+package com.enonic.app.simpleidprovider;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class ConfigTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/lib/config-test.js";
+    }
+}

--- a/src/test/resources/lib/config-test.js
+++ b/src/test/resources/lib/config-test.js
@@ -46,3 +46,26 @@ exports.testGetSiteReturnsDefinedValueWhenOnlyTitleIsSet = function () {
     assert.assertTrue(site !== undefined);
     assert.assertTrue(site.indexOf("undefined") === -1);
 };
+
+exports.testGetForgotPasswordEnabledWhenItemSetPresentWithoutSite = function () {
+    // Regression guard: the feature must be enabled by the forgotPassword ItemSet
+    // being present, not by the removed `site` field.
+    authMock.mockIdProviderConfig({
+        title: "User Login",
+        forgotPassword: {
+            email: "noreply@example.com"
+        }
+    });
+
+    const forgotPassword = configLib.getForgotPassword();
+    assert.assertNotNull(forgotPassword);
+    assert.assertEquals("noreply@example.com", forgotPassword.email);
+};
+
+exports.testGetForgotPasswordNullWhenItemSetAbsent = function () {
+    authMock.mockIdProviderConfig({
+        title: "User Login"
+    });
+
+    assert.assertTrue(configLib.getForgotPassword() === null);
+};

--- a/src/test/resources/lib/config-test.js
+++ b/src/test/resources/lib/config-test.js
@@ -1,0 +1,48 @@
+const authMock = require('/lib/xp/mock/auth');
+const configLib = require('/lib/config');
+const assert = require('/lib/xp/testing');
+
+exports.testGetSiteReadsTopLevelSiteName = function () {
+    authMock.mockIdProviderConfig({
+        title: "User Login",
+        siteName: "Acme Corp",
+        forgotPassword: {
+            email: "noreply@example.com",
+            site: "OldSite"
+        }
+    });
+
+    assert.assertEquals("Acme Corp", configLib.getSite());
+};
+
+exports.testGetSiteFallsBackToForgotPasswordSite = function () {
+    authMock.mockIdProviderConfig({
+        title: "User Login",
+        forgotPassword: {
+            email: "noreply@example.com",
+            site: "LegacySite"
+        }
+    });
+
+    assert.assertEquals("LegacySite", configLib.getSite());
+};
+
+exports.testGetSiteFallsBackToTitleWhenTwoFactorEnabledAndForgotPasswordDisabled = function () {
+    authMock.mockIdProviderConfig({
+        title: "Acme Login",
+        twoFactorEmail: {}
+    });
+
+    assert.assertEquals("Acme Login", configLib.getSite());
+};
+
+exports.testGetSiteReturnsDefinedValueWhenOnlyTitleIsSet = function () {
+    authMock.mockIdProviderConfig({
+        title: "User Login"
+    });
+
+    const site = configLib.getSite();
+    assert.assertNotNull(site);
+    assert.assertTrue(site !== undefined);
+    assert.assertTrue(site.indexOf("undefined") === -1);
+};

--- a/src/test/resources/lib/xp/mock/auth.js
+++ b/src/test/resources/lib/xp/mock/auth.js
@@ -31,6 +31,7 @@ const mock = {
 exports.mockIdProviderConfig = function(data) {
     idProviderConfigJson = {
         title: data.title,
+        siteName: data.siteName,
         emailCode: data.emailCode,
         forgotPassword: data.forgotPassword,
     }


### PR DESCRIPTION
## Summary
- Move "Site name" out of the Forgot Password group to a top-level `siteName` field on the ID Provider config so it can be configured even when Forgot Password is disabled.
- `getSite()` now prefers the top-level `siteName`, falls back to the legacy `forgotPassword.site` (for existing configurations), and finally falls back to the ID Provider `title` (which itself defaults to "User Login") — so the 2FA email subject/body never contains "undefined".
- Added unit tests for `getSite()` covering all three fallback tiers.

Closes #63

## Behavior across issue states
| State | 2FA | Forgot Password | Before | After |
| --- | --- | --- | --- | --- |
| 1 | off | off | site name not used | unchanged |
| 2 | on | off (never enabled) | `undefined` | top-level `siteName` (default `"MyWebsite"`) or title |
| 3 | on | on | configured (`forgotPassword.site` or `siteName`) | same — plus new field |
| 4 | off | on | configured | same |
| 5 | on | off (previously enabled) | previous `forgotPassword.site` value | previous `forgotPassword.site` value preserved as legacy fallback |

## Test plan
- [x] `./gradlew build` green (11 tests, no failures)
- [x] New `ConfigTest` covers: top-level `siteName` wins; legacy `forgotPassword.site` fallback still works when top-level absent; `title` fallback kicks in when both are absent (the 2FA-only case from the issue); result is never `undefined`
- [ ] Manual verify in an XP instance with 2FA on / Forgot Password off — email subject/body show a defined site name

🤖 Generated with [Claude Code](https://claude.com/claude-code)