### PR TITLE
GraalJS Compatibility #102

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,24 +23,15 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:6.1.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.2'
-    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 test {
     useJUnitPlatform()
 }
 
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
 }
-
-check.dependsOn testGraalJs
 
 repositories {
     mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -23,11 +23,24 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:6.1.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:6.1.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:6.1.2'
+    testRuntimeOnly 'org.graalvm.polyglot:js:25.0.3'
 }
 
 test {
     useJUnitPlatform()
 }
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs
 
 repositories {
     mavenLocal()

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@
 group = com.enonic.app
 projectName = simpleidprovider
 appName = com.enonic.app.simpleidprovider
-xpVersion = 8.0.2
+xpVersion = 8.1.0-SNAPSHOT
 version = 3.0.0-SNAPSHOT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ http-client = "4.0.0"
 mustache = "3.0.0"
 router = "4.0.0"
 static = "3.0.0"
-text-encoding = "3.0.0"
+text-encoding = "3.0.0-SNAPSHOT"
 
 [libraries]
 lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.enonic.xp.settings' version '4.1.0'
+    id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = projectName

--- a/src/main/resources/lib/gravatar.js
+++ b/src/main/resources/lib/gravatar.js
@@ -1,5 +1,5 @@
 exports.hash = function (email) {
     var bean = __.newBean('com.enonic.app.simpleidprovider.GravatarHashHandler');
-    bean.email = email;
+    bean.setEmail(email);
     return bean.execute();
 };

--- a/src/test/java/com/enonic/app/simpleidprovider/GravatarScriptTest.java
+++ b/src/test/java/com/enonic/app/simpleidprovider/GravatarScriptTest.java
@@ -1,0 +1,13 @@
+package com.enonic.app.simpleidprovider;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class GravatarScriptTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/lib/gravatar-test.js";
+    }
+}

--- a/src/test/resources/lib/gravatar-test.js
+++ b/src/test/resources/lib/gravatar-test.js
@@ -1,0 +1,6 @@
+const gravatarLib = require('/lib/gravatar');
+const assert = require('/lib/xp/testing');
+
+exports.testHash = function () {
+    assert.assertEquals('0f7675b377ff59e85e37ed6ab24969d9', gravatarLib.hash('noreply@enonic.com'));
+};


### PR DESCRIPTION
Fixes #102

## What

`lib/gravatar.js` set the `GravatarHashHandler` email Nashorn-style. GraalJS does not map
`bean.email = email` to `setEmail(email)` — the shorthand went away with nashorn-compat
mode (enonic/xp#9236) — and `GravatarHashHandler` exposes only `setEmail`, so there is no
`email` member to write:

```
TypeError: writeMember (email) on com.enonic.app.simpleidprovider.GravatarHashHandler
failed due to: Unknown identifier: email
```

The write now calls the setter. `email` is the sole required argument of `hash(email)` and its
only caller (`lib/render/render.js`) already guards `if (user.email && ...)`, so it never
reaches the `String` setter as `undefined` — no `__.nullOrValue` wrapper is needed here.

## Tested on both engines

The JS tests now run once per script engine — Nashorn via `test` (the platform default) and
GraalJS via `testGraalJs` — both wired into `check`, mirroring `gradle/js-tests.gradle` in the
platform. A new `GravatarScriptTest` / `lib/gravatar-test.js` exercises `gravatar.hash`, so the
fix is actually covered on both engines (the existing suite never reached that code path):

```
test         (Nashorn)  GravatarScriptTest.testHash  PASS
testGraalJs  (GraalJS)  GravatarScriptTest.testHash  PASS   (FAILS with the TypeError before the fix)
```

Reverting the setter makes `testGraalJs` fail that test with the `writeMember` `TypeError`
above — exactly the divergence the second engine exists to catch.

## Why `testGraalJs` is red (draft)

Two independent, out-of-scope blockers keep the full `testGraalJs` run red for now:

1. **Platform.** `testGraalJs` needs the `ScriptRunnerSupport` fix from enonic/xp#12198 (it keeps
   the script executor alive through JS test discovery; the old one closes it and every GraalJS
   test then fails with `The Context is already closed`). That is why `xpVersion` is bumped to
   `8.1.0-SNAPSHOT` with `enonicRepo('dev')` — **but the snapshot currently on
   repo.enonic.com/dev still carries the old `ScriptRunnerSupport`**, so CI stays red until
   enonic/xp#12198 is merged and a fresh `8.1.0-SNAPSHOT` is published.

2. **Dependency.** Even against a local `publishToMavenLocal` build of enonic/xp#12198, four
   two-step tests still fail — not in this repo's code, but in the bundled
   `com.enonic.lib:lib-text-encoding` 3.0.0, which has the *same* property-write bug in its own
   `/lib/text-encoding.js` (`bean.stream = stream`, reached via `textEncoding.sha256(...)`):

   ```
   TypeError: writeMember (stream) on com.enonic.lib.textencoding.HashFunctionHandler
   failed due to: Unknown identifier: stream
   ```

   That belongs to lib-text-encoding and needs its own GraalJS-compatibility fix
   (`HashFunctionHandler` already has `setStream`); it is out of scope here, and there is no
   fixed release to bump to yet. **This app's own JavaScript is now GraalJS-clean** — the only
   own-code site was `gravatar.js`, fixed and covered above.

Local result against a `publishToMavenLocal` build of enonic/xp#12198 (GraalVM CE 25):

```
test         20 tests, 0 failed
testGraalJs  20 tests, 4 failed   (all 4 in lib-text-encoding; GravatarScriptTest green)
```

## Not included

The issue also notes `task.executeFunction` in `main.js` as deprecated on GraalJS. That is a
separate concern (not a property write) and is left out of this PR, which is scoped to the
property-write fix and the dual-engine test wiring.

Holding as a draft until enonic/xp#12198 publishes (and lib-text-encoding ships its own fix).
